### PR TITLE
fix: include dive tag

### DIFF
--- a/validation_tags_to_schema.go
+++ b/validation_tags_to_schema.go
@@ -192,6 +192,8 @@ func ValidationTagsToSchema(validationTag string) (tagSchema Schema, required bo
 			schema.Pattern = "^urn:[a-zA-Z0-9][a-zA-Z0-9-]{0,31}:([a-zA-Z0-9()+,\\-.:=@;$_!*'%/?#]|%[0-9a-fA-F]{2})+$"
 
 		// Primitives
+		case "dive":
+			continue
 		case "required":
 			fieldRequired = true
 

--- a/validation_tags_to_schema_test.go
+++ b/validation_tags_to_schema_test.go
@@ -659,6 +659,11 @@ func TestValidateTagsToSchema(t *testing.T) {
 			expectedSchema: singleSchemaFromPattern("^urn:[a-zA-Z0-9][a-zA-Z0-9-]{0,31}:([a-zA-Z0-9()+,\\-.:=@;$_!*'%/?#]|%[0-9a-fA-F]{2})+$"),
 		},
 		{
+			name:           "dive",
+			validateTag:    "dive",
+			expectedSchema: allOfSchemas(),
+		},
+		{
 			name:        "required",
 			validateTag: "required",
 			required:    true,


### PR DESCRIPTION
This PR now includes the `dive` tag, this is a very basic implementation where the dive tag is ignored as it was adding an empty object to the all of object, In the future this will needed to be handled differently but without the context of what type the tag is coming from we cannot handle that yet.