### PR TITLE
fix: empty tag

### DIFF
--- a/validation_tags_to_schema.go
+++ b/validation_tags_to_schema.go
@@ -192,6 +192,8 @@ func ValidationTagsToSchema(validationTag string) (tagSchema Schema, required bo
 			schema.Pattern = "^urn:[a-zA-Z0-9][a-zA-Z0-9-]{0,31}:([a-zA-Z0-9()+,\\-.:=@;$_!*'%/?#]|%[0-9a-fA-F]{2})+$"
 
 		// Primitives
+		case "":
+			continue
 		case "required":
 			fieldRequired = true
 

--- a/validation_tags_to_schema_test.go
+++ b/validation_tags_to_schema_test.go
@@ -659,6 +659,11 @@ func TestValidateTagsToSchema(t *testing.T) {
 			expectedSchema: singleSchemaFromPattern("^urn:[a-zA-Z0-9][a-zA-Z0-9-]{0,31}:([a-zA-Z0-9()+,\\-.:=@;$_!*'%/?#]|%[0-9a-fA-F]{2})+$"),
 		},
 		{
+			name:           "empty",
+			validateTag:    "",
+			expectedSchema: Schema{},
+		},
+		{
 			name:        "required",
 			validateTag: "required",
 			required:    true,


### PR DESCRIPTION
This PR Resolves the issue where an empty tag or a tag with multiple `,,` would produce a schema where `allOf` array containing a list of empty schemas.